### PR TITLE
fix: use static URL in install script to support choco download --internalize

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $packageName = 'opencode'
 $version = $env:chocolateyPackageVersion
 
-$url64 = "https://github.com/anomalyco/opencode/releases/download/v$version/opencode-windows-x64.zip"
+$url64 = 'https://github.com/anomalyco/opencode/releases/download/vPLACEHOLDER_VERSION/opencode-windows-x64.zip'
 
 Write-Host "opencode $version"
 

--- a/update.ps1
+++ b/update.ps1
@@ -170,9 +170,14 @@ try {
     
     # Replace the checksum (looking for either PLACEHOLDER_CHECKSUM or an actual checksum)
     $installScript = $installScript -replace "checksum64\s*=\s*'([A-F0-9]{64}|PLACEHOLDER_CHECKSUM)'", "checksum64     = '$checksum'"
-    
+
+    # Replace the version placeholder in the URL so the published nupkg contains a fully
+    # resolved, static URL. This allows `choco download --internalize` to fetch the asset
+    # at scan time without hitting a 404 caused by an unresolved PowerShell variable.
+    $installScript = $installScript -replace 'releases/download/v[^/]+/opencode', "releases/download/v$latestVersion/opencode"
+
     Set-Content -Path $installScriptPath -Value $installScript -NoNewline
-    Write-Log "Updated checksum in chocolateyinstall.ps1" "Success"
+    Write-Log "Updated version and checksum in chocolateyinstall.ps1" "Success"
     
     # Auto-commit if requested
     if ($AutoCommit) {


### PR DESCRIPTION
## Problem

`choco download --internalize` fails with a 404 when trying to internalize this package:

`
The remote file either doesn't exist, is unauthorized, or is forbidden for url
'https://github.com/anomalyco/opencode/releases/download/v$env:chocolateyPackageVersion/opencode-windows-x64.zip'
`

The Chocolatey internalizer performs a **static text scan** for URLs in the install script — it does not execute PowerShell. Because the download URL is built from a runtime variable (``), the internalizer tries to fetch the URL literally, with `` unresolved, and receives a 404.

This is a [documented limitation](https://docs.chocolatey.org/en-us/features/package-internalizer) of the Chocolatey internalizer: *"variables with methods"* and dynamic URL construction cannot be automatically resolved.

## Fix

Two changes:

1. **`tools/chocolateyinstall.ps1`** — replace the interpolated URL with a `PLACEHOLDER_VERSION` token (same pattern already used for the checksum).
2. **`update.ps1`** — rewrite the placeholder to the resolved version string alongside the existing checksum replacement, so every published `.nupkg` contains a fully static URL like `https://github.com/anomalyco/opencode/releases/download/v1.14.29/opencode-windows-x64.zip`.

This is consistent with how the checksum is already handled and requires no change to the release/publish workflow.